### PR TITLE
governance: pull request rot

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -68,7 +68,7 @@ The end of the voting window should be in YYYY-MM-DD hh:mm (ISO 8601) with UTC t
 | Term | Definition | Synopsis |
 | ---- | ---------- | -------- |
 | Stale | PR has been inactive for 90+ days. | PRs will be labeled as "stale". An inactive, stale PR may be marked "rotten" after 30 days. |
-| Rotten | Stale PR has been inactive for 30+ days. | PRs will be labeled as "rotten". An inactive, rotten PR may be deleted after 30 days of being marked "rotten". |
+| Rotten | Stale PR has been inactive for 30+ days. | PRs will be labeled as "rotten". An inactive, rotten PR may be closed after 30 days of being marked "rotten". |
 
 The process of marking PRs as *stale* or *rotten* is currently a manual one.
 In the future this process will be automated.

--- a/governance.md
+++ b/governance.md
@@ -62,3 +62,13 @@ The end of the voting window should be in YYYY-MM-DD hh:mm (ISO 8601) with UTC t
 #### Tallying results
 
 `[VOTE RESULT]: {Motion Description}`
+
+## Pull Request Rot
+
+| Term | Definition | Synopsis |
+| ---- | ---------- | -------- |
+| Stale | PR has been inactive for 90+ days. | PRs will be labeled as "stale". An inactive, stale PR may be marked "rotten" after 30 days. |
+| Rotten | Stale PR has been inactive for 30+ days. | PRs will be labeled as "rotten". An inactive, rotten PR may be deleted after 30 days of being marked "rotten". |
+
+The process of marking PRs as *stale* or *rotten* is currently a manual one.
+In the future this process will be automated.


### PR DESCRIPTION
We need to clean up some old PRs in the CSI repos. In a recent CSI community sync we discussed adopting a stale/rotten PR policy similar to that of k8s. The 90 day staleness window roughly corresponds with the initial release window goals that we had while pushing toward CSI v1.0. Post 1.0, I expect that the time between releases will be much longer and so picking a fixed duration (like 90d) makes it easier to implement a stale/rotten PR policy vs. one that's based on a variable release cycle.